### PR TITLE
docs: dark/light switcher, make docs-serve

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,11 @@ docs: docs-diagrams
 .PHONY: docs-diagrams
 docs-diagrams: $(images_svg)
 
+.PHONY: docs-serve
+docs-serve:
+	( find docs ; echo mkdocs.yml ) | entr -rs \
+		'$(MAKE) --no-print-directory -i docs-diagrams && mkdocs serve --no-livereload'
+
 # Diagrams: generate SVG images from d2 sources.
 #
 # '--layout dagre' is used by default; skipping it allows to set layout on a

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,7 +7,14 @@ edit_uri: https://github.com/roc-streaming/rocd/edit/main/docs/
 theme:
   name: material
   palette:
-    scheme: slate
+    - scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
gh-15

Changes:

- docs: dark/light switcher
- docs: make docs-serve (requires [entr](https://github.com/eradman/entr))
